### PR TITLE
Add support for setting python binary in a config file

### DIFF
--- a/pony-mode.el
+++ b/pony-mode.el
@@ -76,6 +76,14 @@ projects using sqlite."
   (let ((s (if (symbolp str) (symbol-name str) str)))
     (replace-regexp-in-string "\\(^[[:space:]\n]*\\|[[:space:]\n]*$\\)" "" s)))
 
+(defun get-string-from-file (filePath)
+  "Return FILEPATH's file content."
+  (condition-case nil
+      (chomp (with-temp-buffer
+	(insert-file-contents filePath)
+	(buffer-string)))
+    (error nil)))
+
 ;;;###autoload
 (defun pony-find-file (path pattern)
   "Find files matching pattern in or below path"
@@ -250,10 +258,15 @@ This command will only work if you run with point in a buffer that is within you
 (defun pony-active-python ()
   "Fetch the active Python interpreter for this Django project.
 Be aware of 'clean', buildout, and virtualenv situations"
-  (let ((venv-out (pony-locate "bin/python")))
-    (if venv-out
-        venv-out
-      (executable-find "python"))))
+  (let (
+	(conf-venv-bin (get-string-from-file (concat
+					      (pony-project-root)
+					      "/.ponyrc")))
+	(venv-out (pony-locate "bin/python"))
+	)
+    (cond (conf-venv-bin conf-venv-bin)
+	  (venv-out venv-out)
+	  (t (executable-find "python")))))
 
 ;;;###autoload
 (defun pony-command-exists(cmd)


### PR DESCRIPTION
The idea is to have a file .ponyrc in the django project root and be able to set (at least for now) the preferred python binary to run the commands. This way I can use the python version and environment I want, no matter where it's located.
I'm using this because I have my virtualenvs in a different directory and sometimes I reuse them.
I'm sorry about the code quality, it's the first time I write "real" elisp (not just config).
Really cool mode by the way :)
Cheers!
