### PR TITLE
Comment tag problems

### DIFF
--- a/pony-tpl.el
+++ b/pony-tpl.el
@@ -47,6 +47,7 @@
    (list
     '("{%.*\\(\\bor\\b\\).*%}" . (1 font-lock-builtin-face))
     ;'("{% ?comment ?%}\\(\n?.*?\\)+?{% ?endcomment ?%}" . font-lock-comment-face)
+    '("{#.*#}" . font-lock-comment-face)
     '("{% ?\\(\\(end\\)?\\(extends\\|for\\|cache\\|cycle\\|filter\\|firstof\\|debug\\|if\\(changed\\|equal\\|notequal\\|\\)\\|include\\|load\\|now\\|regroup\\|spaceless\\|ssi\\|templatetag\\|widthratio\\|block\\|trans\\)\\) ?.*? ?%}" . 1)
     '("{{ ?\\(.*?\\) ?}}" . (1 font-lock-variable-name-face))
     '("{%\\|\\%}\\|{{\\|}}" . font-lock-builtin-face)


### PR DESCRIPTION
Issue #15.

With a clean emacs and pony-mode type the following in a blank HTML PonyTpl buffer:

`{% comment %}asdfghjklzxcvb...`

After roughly 20 characters emacs will start to slow down. Each character after that exponentially (?) increases the time emacs _appears_ to hang for. This means PonyTpl is unusable for templates containing anything but trivial comments.

The temporary fix is to disable line 50 of pony-tpl.el.

As an aside, PonyTpl was not aware of the single line comment idiom: `{# ..... #}`.
