### PR TITLE
New startproject srtucture

### DIFF
--- a/pony-mode.el
+++ b/pony-mode.el
@@ -154,8 +154,12 @@ It creates a comint interaction buffer, called `name', running
 wrapper around `pony-commint-pop', this function bypasses the
 need to construct manage.py calling sequences in command
 functions."
-  (let ((python-args
-	 (cons command (append args (list (concat "--settings=" (pony-get-settings-file-basename)))))))
+  (let* ((settings (if (pony-project-newstructure-p)
+		       (concat (pony-project-package) "."
+			       (pony-get-settings-file-basename))
+		     (pony-get-settings-file-basename)))
+	(python-args
+	 (cons command (append args (list (concat "--settings=" settings))))))
     (pony-comint-pop name (pony-active-python) python-args)))
 
 ;;;###autoload


### PR DESCRIPTION
Django trunk [change](https://code.djangoproject.com/changeset/16964) the [layout of projects](https://groups.google.com/group/django-developers/browse_frm/thread/44b70a37ff73298b?pli=1). Changes provided in this pull request make pony-mode work with new and old type structure. 
