### PR TITLE
Fix pony-list-commands

### DIFF
--- a/pony-mode.el
+++ b/pony-mode.el
@@ -602,7 +602,7 @@ locally with .ponyrc."
 ;;;###autoload
 (defun pony-list-commands()
   "List of managment commands for the current project"
-  (let ((command (concat (pony-active-python) " " (pony-manage-cmd))))
+  (let ((command (concat (pony-active-python) " " (pony-manage-cmd) " --help")))
     (with-temp-buffer
       (insert (shell-command-to-string command))
       (goto-char (point-min))


### PR DESCRIPTION
When I tried to use pony-manage it was throwing an error on me from inside `pony-list-commands`. First commit in this pull request  solves that. Then it occurred that `pony-list-commands` do not return any results in my installation due to regex mismatch. When I was testing if new regex do not break anything in older django releases I make `pony-list-commands` also more polite to old django versions (so old that hopefully nobody uses them :) but as I was already there...). All of this end up as fairly simple and much shorter patch than this comment :)

Regards
