### PR TITLE
Pony browser logic

### DIFF
--- a/pony-mode.el
+++ b/pony-mode.el
@@ -701,8 +701,15 @@ This function allows you to run a server with a 'throwaway' host:port"
   (interactive)
   (let ((url (concat "http://" pony-server-host ":"  pony-server-port))
         (proc (get-buffer-process "*ponyserver*")))
-    (if (not proc)
-        (pony-runserver))
+    ;; use actual url if process is already running
+    (if proc
+	(save-excursion
+	  (progn
+	    (set-buffer "*ponyserver*")
+	    (goto-char (point-max))
+	    (if (search-backward-regexp "Development server is running at \\(.+\\)\n")
+		(setq url (match-string-no-properties 1)))))
+      (pony-runserver))
     (run-with-timer 2 nil 'browse-url url)))
 
 ;; Shell


### PR DESCRIPTION
This code makes pony-browser use url with current value from running server or default ones if dev server is not running instead of hard coded url.
