### PR TITLE
Multiple args for management command

### DIFF
--- a/pony-mode.el
+++ b/pony-mode.el
@@ -619,7 +619,12 @@ locally with .ponyrc."
 
 ;;;###autoload
 (defun pony-manage()
-  "Interactively call the pony manage command"
+  "Interactively call the pony manage command.
+
+Second string that is read from minibuffer may be an actual
+list of space separated arguments for previously chosen management
+command. If some of the arguments contain space itself they should be quoted
+with double quotes like \"...\"."
   (interactive)
   (let* ((command (minibuffer-with-setup-hook 'minibuffer-complete
                               (completing-read "Manage: "


### PR DESCRIPTION
`pony-manage` wasn't capable of digesting string with multiple arguments for management command. Well, with this patch, it will be.

From commit message:

```
Treat argument for management command as group of space separated arguments

Treat second argument obtained interactively for pony-manage as space
separated list of arguments. This made possible running management
commands that may take more than one argument.

If argument contain space itself it should be quoted with double
quotes "...".
```

I hope you find these helpful.
