### PR TITLE
Make testing pony-mode a bit easier

### DIFF
--- a/runquiet.sh
+++ b/runquiet.sh
@@ -1,2 +1,4 @@
-#!/bin/bash
-emacs --no-desktop -q -Q --load ./tests/resources/init.el --debug-init
+#!/bin/sh
+
+MYPATH=$(dirname $(readlink -f $0))
+emacs --no-desktop -q -Q --load "$MYPATH"/tests/resources/init.el --debug-init

--- a/tests/resources/init.el
+++ b/tests/resources/init.el
@@ -3,7 +3,10 @@
 ;; level of cognitive dissonance incurred when firing up configuration-lite
 ;; instances of Emacs for testing purposes
 
-(add-to-list 'load-path "~/emacs/site-packages/pony-mode")
+(add-to-list 'load-path
+             (expand-file-name
+              (concat (file-name-directory load-file-name)
+                      "../../")))
 (require 'pony-mode)
 
 (global-set-key [M-left] 'windmove-left) ; move to left windnow


### PR DESCRIPTION
- Let runquiet.sh work when run from anywhere including through
  symlink.
- Make init.el find pony-mode relative to itself instead of
  searching for it in fixed location.
### Rationale:

As it is now it may pose some difficulties for new comers. That is because place where testing installation of `pony-mode` is expected to be now, may be in conflict with their stable installation. In addition, running `runquiet,sh` from some other directory than project root may be useful for everybody.
