### PR TITLE
Fix for broken pony-test; also fixes for #43, #44, #45

### DIFF
--- a/pony-mode.el
+++ b/pony-mode.el
@@ -556,8 +556,8 @@ locally with .dir-locals.el."
                (sql-password (db-setting "PASSWORD"))
                (sql-database (db-setting "NAME"))
                (sql-server (db-setting "HOST")))
-          (sql-product-interactive)
-          (when (pony-pop "*SQL*")
+          (save-excursion (sql-product-interactive))
+          (when (pony-pop "*SQL*" :dirlocals t)
             (rename-buffer buffer-name t)))))))
 
 ;; Fabric


### PR DESCRIPTION
I broke `pony-test` — sorry about that. When I moved the computation of the `command` into the `(interactive)` form I moved the computation of `failfast` too, which was a mistake. Now fixed and tested.

I contributed fixes for #43, #44, and #45 too.
