### PR TITLE
A couple of pony-goto-template fixes. 

### DIFF
--- a/pony-mode.el
+++ b/pony-mode.el
@@ -613,7 +613,7 @@ locally with .dir-locals.el."
 (defun pony-convert-string-sequence(python-string)
   "Convert a python sequence of strings to its lisp equivalent"
   (split-string
-   (replace-regexp-in-string "[\][\(\)'\"]" "" python-string) ", ?"))
+   (replace-regexp-in-string "[][()'\"]" "" python-string) ", ?"))
 
 ;;;###autoload
 (defun pony-find-file-in-path(file path)


### PR DESCRIPTION
Hi David,

I found pony-goto-template to be broken for me when settings.TEMPLATE_DIRS contains multiple directories, which this change addresses. It also allows pony-goto-template to work when point is anywhere on a line containing a template name (previously it only worked for me when point was at the beginning of the line).

I tested using your handy runquiet.sh script.

Thanks,
Jacob
