### PR TITLE
add defcustom to disable pony-tpl-mode

### DIFF
--- a/src/pony-mode.el
+++ b/src/pony-mode.el
@@ -75,6 +75,11 @@ projects using sqlite."
   :group 'pony
   :type 'string)
 
+(defcustom pony-enable-template-mode t
+  "Enable Django template mode?"
+  :group 'pony
+  :type 'bool)
+
 (defvar pony-filesystem-ceiling (if (eq 'windows-nt system-type)
                                     "c:/" "/"))
 
@@ -1131,7 +1136,8 @@ If the project has the django_extras package installed, then use the excellent
 (add-hook 'html-mode-hook
            (lambda ()
              (if (pony-project-root)
-                   (pony-tpl-mode))))
+                 (if pony-enable-template-mode
+                       (pony-tpl-mode)))))
 
 (add-hook 'dired-mode-hook
           (lambda ()


### PR DESCRIPTION
I use pony-mode for regular django files but for templates i prefer nxhtml/mumamo. Enabling pony-tpl-mode and nxhtml on the same template file leads to weird behavior. Therefore I'd like a way to disable pony-tpl-mode. 

I only started using emacs last week so my elisp is really ropey - please let me know if there is some far easier way to do this.
