### PR TITLE
pony-indent now behaves like other indent-line-functions.

### DIFF
--- a/src/pony-mode.el
+++ b/src/pony-mode.el
@@ -75,9 +75,6 @@ projects using sqlite."
   :group 'pony
   :type 'string)
 
-(defcustom pony-tpl-indent-moves nil
-  "Should TAB move (point) ? if set to t, TAB will move (point)."
-
 (defcustom pony-enable-template-mode t
   "Enable Django template mode?"
   :group 'pony

--- a/src/pony-tpl.el
+++ b/src/pony-tpl.el
@@ -92,15 +92,16 @@
 (defun pony-indent ()
   "Indent current line as Jinja code"
   (interactive)
-  (flet ((indenter ()
-                   (beginning-of-line)
-                   (let ((indent (pony-calculate-indent)))
-                     (if (< indent 0)
-                         (setq indent 0))
-                     (indent-line-to indent))))
-    (if pony-tpl-indent-moves
-        (indenter)
-      (save-excursion (indenter)))))
+  (let ((pos (- (point-max) (point)))
+        (indent (pony-calculate-indent)))
+    (if (< indent 0)
+        (setq indent 0))
+    (indent-line-to indent)
+    ;; If initial point was within line's indentation,
+    ;; position after the indentation.  Else stay at same point in text.
+    (let ((moved-pos (- (point-max) pos)))
+     (if (> moved-pos (point))
+         (goto-char moved-pos)))))
 
 (defvar pony-tpl-mode-hook nil)
 


### PR DESCRIPTION
In Emacs, the point moves to the end of indentation if the point came
before the first non-whitespace character in a line. Otherwise, the
point stays put, relative to the text.

See issue #55.
