### PR TITLE
Use the more generic which-function

### DIFF
--- a/src/pony-mode.el
+++ b/src/pony-mode.el
@@ -97,6 +97,7 @@ projects using sqlite."
 (require 'sgml-mode)
 (require 'sql)
 (require 'thingatpt)
+(require 'which-func)
 
 ;; Utility
 
@@ -949,7 +950,7 @@ If the project has the django_extras package installed, then use the excellent
 (defun pony-test (command)
   "Run the test(s) given by `command'."
   (interactive
-   (let* ((defuns (subseq (split-string (python-current-defun) "\\.") 0 2))
+   (let* ((defuns (subseq (split-string (which-function) "\\.") 0 2))
           (class (first defuns))
           (func (let ((f (second defuns))) (and f (string-match "^test" f) f)))
           (app (pony-get-app))


### PR DESCRIPTION
python-current-defun isn't present in all python modes that may be in
use, but this should be resolved by using which-func.  See issue #65.
