### PR TITLE
Indent fix

### DIFF
--- a/src/pony-tpl.el
+++ b/src/pony-tpl.el
@@ -56,7 +56,7 @@
 
 (defun pony-calculate-indent-backward (default)
   "Return indent column based on previous lines"
-  (let ((indent-width sgml-basic-offset) (default (sgml-indent-line-num)))
+  (let ((indent-width sgml-basic-offset))
     (forward-line -1)
     (if (looking-at "^[ \t]*{%-? *end") ; Don't indent after end
         (current-indentation)
@@ -72,13 +72,13 @@
 
 (defun pony-calculate-indent ()
   "Return indent column"
-  (if (bobp)  ; Check begining of buffer
-      0
-    (let ((indent-width sgml-basic-offset) (default (sgml-indent-line-num)))
-      (save-excursion
-        (beginning-of-line)
+  (save-excursion
+    (beginning-of-line)
+    (if (bobp)  ; Check begining of buffer
+        0
+      (let ((indent-width sgml-basic-offset) (default (sgml-indent-line-num)))
         (if (looking-at "^[ \t]*{%-? *e\\(nd\\|lse\\|lif\\)") ; Check close tag
-            (save-excursion
+            (progn
               (forward-line -1)
               (if
                   (and
@@ -88,8 +88,7 @@
                 (- (current-indentation) indent-width)))
           (if (looking-at "^[ \t]*</") ; Assume sgml end block trust sgml
               default
-            (save-excursion
-              (pony-calculate-indent-backward default))))))))
+            (pony-calculate-indent-backward default)))))))
 
 (defun pony-indent ()
   "Indent current line as Jinja code"


### PR DESCRIPTION
These changes fix two cases for me:
1. Some inconsisency with indentation depending on the location of the
   cursor, for example (with | as the cursor position):
   
   ``` html
   {% if sometest %}
     <div>say something</div>
   {% endif %}|
   ```
   
   With the cursor in that position it will indent as:
   
   ``` html
   {% if sometest %}
    <div>say something</div>
    {% endif %}
   ```
   
   But with the cursor at the beginning of the line it will indent
   correctly.
2. Using the wrong indentation for certain strangely structured tags.
   Where an couple of elements should look like this:
   
   ``` html
   <input type="text"
          class="some class" />
   <input type="text"
          class="some other class" />
   ```
   
   Come out looking like:
   
   ``` html
   <input type="text"
          class="some class" />
          <input type="text"
                 class="some other class" />
   ```

Please let me know what you think.
