### PR TITLE
Tag & indent

### DIFF
--- a/src/pony-tpl.el
+++ b/src/pony-tpl.el
@@ -33,7 +33,7 @@
 
 (defvar pony-indenting-tags
   '("autoescape" "block" "blocktrans" "comment" "elif" "else" "empty"
-    "filter" "for" "if" "ifchanged" "ifequal" "ifnotequal" "spaceless" "verbatim" "with")
+    "filter" "for" "if" "ifchanged" "ifequal" "ifnotequal" "plural" "spaceless" "verbatim" "with")
   "List of template tags that imply indentation.")
 
 (defvar pony-indenting-tags-regexp
@@ -77,7 +77,7 @@
     (if (bobp)  ; Check begining of buffer
         0
       (let ((indent-width sgml-basic-offset) (default (sgml-indent-line-num)))
-        (if (looking-at "^[ \t]*{%-? *e\\(nd\\|lse\\|lif\\|mpty\\)") ; Check close tag
+        (if (looking-at "^[ \t]*{%-? *\\(e\\(nd\\|lse\\|lif\\|mpty\\)\\|plural\\)") ; Check close tag
             (progn
               (forward-line -1)
               (if


### PR DESCRIPTION
Hi,

These have been bugging me for a while. I finally got around to fixing them. Please let me know what you think about including them.
- Add `empty` tag as closing tag, which does the same for `for` as `else` and `elif` do for `if`.
- Add `plural` tag as indenting and closing tag, which is similar (syntax-wise) to `empty` for `for` and `else` and `elif` for `if`. It's explained [here](https://docs.djangoproject.com/en/1.5/topics/i18n/translation/#blocktrans-template-tag).
