### PR TITLE
Fix pony-browser string matching

### DIFF
--- a/src/pony-mode.el
+++ b/src/pony-mode.el
@@ -647,9 +647,13 @@ to its lisp equivalent"
    (replace-regexp-in-string "[][()'\"]" "" python-string) ", ?"))
 
 (defun pony-find-file-in-path(file path)
-  "Find FILE if it exists in one the directories in PATH"
+  "Find FILE if it exists in one the directories in PATH.
+
+If path doesn't exist in default-directory try to search it in
+parent directories.
+"
   (dolist (dir path)
-    (let ((file-absolute (expand-file-name file dir)))
+    (let ((file-absolute (expand-file-name file (pony-locate dir))))
       (if (file-exists-p file-absolute)
           (return (find-file file-absolute))))))
 


### PR DESCRIPTION
If I run pony-runserver the development server URL is reported on a line like:

`
Starting development server at http://localhost:8000/
`

But pony-browser tries to match:

`
Development server is running at http://localhost:8000/
`

This fix matches both versions.
