### PR TITLE
Fix pony-goto-template for projects with TEMPLATE_DIRS in project root

### DIFF
--- a/src/pony-mode.el
+++ b/src/pony-mode.el
@@ -647,9 +647,13 @@ to its lisp equivalent"
    (replace-regexp-in-string "[][()'\"]" "" python-string) ", ?"))
 
 (defun pony-find-file-in-path(file path)
-  "Find FILE if it exists in one the directories in PATH"
+  "Find FILE if it exists in one the directories in PATH.
+
+If path doesn't exist in default-directory try to search it in
+parent directories.
+"
   (dolist (dir path)
-    (let ((file-absolute (expand-file-name file dir)))
+    (let ((file-absolute (expand-file-name file (pony-locate dir))))
       (if (file-exists-p file-absolute)
           (return (find-file file-absolute))))))
 


### PR DESCRIPTION
One of my Django projects has the following layout with the templates-directory in the project root like this:

```
.
├── app1
├── app2
├── manage.py
├── static
└── templates
```

The TEMPLATE_DIRS variable is defined like this:

```
# Build paths inside the project like this: os.path.join(BASE_DIR, ...)
import os
BASE_DIR = os.path.dirname(os.path.dirname(__file__))
TEMPLATE_DIRS = (
    os.path.join(BASE_DIR, "templates"),
)
```

This results in the tuple `('templates',)`, but pony-goto-template tries to find the template directory from `app1/templates`. By using pony-locate when expanding the template filename we can accomodate both directory layouts.
