### PR TITLE
pony-test: update the 'manager.py' file for Django >= 1.6

### DIFF
--- a/tests/data/ponytester/manage.py
+++ b/tests/data/ponytester/manage.py
@@ -1,14 +1,9 @@
 #!/usr/bin/env python
-from django.core.management import execute_manager
-import imp
-try:
-    imp.find_module('settings') # Assumed to be in the same directory.
-except ImportError:
-    import sys
-    sys.stderr.write("Error: Can't find the file 'settings.py' in the directory containing %r. It appears you've customized things.\nYou'll have to run django-admin.py, passing it your settings module.\n" % __file__)
-    sys.exit(1)
-
-import settings
+import os, sys
 
 if __name__ == "__main__":
-    execute_manager(settings)
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings")
+
+    from django.core.management import execute_from_command_line
+
+    execute_from_command_line(sys.argv)


### PR DESCRIPTION
Deprecated since Django 1.4. Take a look at the release note:
https://docs.djangoproject.com/en/1.4/releases/1.4/#updated-default-project-layout-and-manage-py

This was the test `pony-command-exists-t` which failed. Hope you use a Django >= 1.4.