### PR TITLE
Fix regexp to always include the word boundary.

### DIFF
--- a/src/pony-tpl.el
+++ b/src/pony-tpl.el
@@ -33,7 +33,7 @@
 
 (defvar pony-indenting-tags
   '("autoescape" "block" "blocktrans" "comment" "elif" "else" "empty"
-    "filter" "form_tag" "for" "if" "ifchanged" "ifequal" "ifnotequal" "plural" "spaceless" "verbatim" "with")
+    "filter" "for" "if" "ifchanged" "ifequal" "ifnotequal" "plural" "spaceless" "verbatim" "with")
   "List of template tags that imply indentation.")
 
 (defvar pony-indenting-tags-regexp
@@ -113,7 +113,7 @@
     '("{%.*\\(\\bor\\b\\).*%}" . (1 font-lock-builtin-face))
     ;'("{% ?comment ?%}\\(\n?.*?\\)+?{% ?endcomment ?%}" . font-lock-comment-face)
     '("{#.*#}" . font-lock-comment-face)
-    (cons (concat "{% *\\(\\(?:end\\)?" (regexp-opt pony-indenting-tags) "\\|" (regexp-opt pony-nonindenting-tags) "\\>\\).*?%}") 1)
+    (cons (concat "{% *\\(\\(?:end\\)?" (regexp-opt pony-indenting-tags) "\\|" (regexp-opt pony-nonindenting-tags) "\\)\\>.*?%}") 1)
     '("{{ ?\\(.*?\\) ?}}" . (1 font-lock-variable-name-face))
     '("{%\\|\\%}\\|{{\\|}}" . font-lock-builtin-face)
     ))


### PR DESCRIPTION
Fixes #80 

The regexp include the word boundary **only** after the `pony-nonindenting-tags`. This is because it was inside the grouping parenthesis but to the right of the vertical bar.